### PR TITLE
Bugfix, empty resonses are returned as 204s from DTR and not 200s are previously thought

### DIFF
--- a/lib/docusign_transaction_rooms/paginated_resource.rb
+++ b/lib/docusign_transaction_rooms/paginated_resource.rb
@@ -67,7 +67,7 @@ module DocusignTransactionRooms
       
       @collection += invoker.handle_response
 
-      meta = MetaInformation.extract_single(invoker.response.body, :read)
+      meta = MetaInformation.extract_single(invoker.response.body, :read) || MetaInformation.new
       @result_size = meta.resultSetSize.to_i
       @next_uri = meta.nextUri
       @previous_uri = meta.previousUri

--- a/lib/docusign_transaction_rooms/resources/room_resource.rb
+++ b/lib/docusign_transaction_rooms/resources/room_resource.rb
@@ -10,6 +10,7 @@ module DocusignTransactionRooms
         query_keys :dateRangeType, :startDate, :endDate, :count, :startPosition
         path "#{DocusignTransactionRooms.configuration.path_url}/rooms"
         handler(200) { |response| RoomMapping.extract_collection(response.body, :read) }
+        handler(204) { |_| [] }
       end
 
       # POST    /v1/rooms

--- a/lib/docusign_transaction_rooms/version.rb
+++ b/lib/docusign_transaction_rooms/version.rb
@@ -1,3 +1,3 @@
 module DocusignTransactionRooms
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/lib/docusign_transaction_rooms/resources/room_resource_test.rb
+++ b/test/lib/docusign_transaction_rooms/resources/room_resource_test.rb
@@ -23,6 +23,16 @@ module DocusignTransactionRooms
       assert_equal (1..123).to_a, rooms.map(&:roomId)
     end
 
+    def test_all_does_not_choke_on_empty_body
+      register_rooms_webmocks
+      connection = DocusignTransactionRooms::Client.new('access_token').connection
+      resource = DocusignTransactionRooms::RoomResource.new(connection: connection)
+      rooms = resource.all(dateRangeType: 'LastUpdated', startDate: '2018-07-18').collect{|room| room}
+
+      assert_instance_of Array, rooms
+      assert_empty rooms
+    end
+
     def test_find_fetches_and_parsers_a_room
       register_rooms_webmocks
       connection = DocusignTransactionRooms::Client.new('access_token').connection

--- a/test/support/request_stub_helpers.rb
+++ b/test/support/request_stub_helpers.rb
@@ -15,6 +15,10 @@ module RequestStubHelpers
     stub_request(:get, "#{DocusignTransactionRooms.configuration.api_url}/#{DocusignTransactionRooms.configuration.path_url}/rooms").
       with(query: {count: 50, startPosition: 100}).
       to_return(status: 200, body: Pathname.new('./test/fixtures/rooms/all_3.json').read)
+
+    stub_request(:get, "#{DocusignTransactionRooms.configuration.api_url}/#{DocusignTransactionRooms.configuration.path_url}/rooms").
+      with(query: {dateRangeType: 'LastUpdated', startDate: '2018-07-18', startPosition: 0, count: 100}).
+      to_return(status: 204, body: '')
   end
 
 


### PR DESCRIPTION
Adding a handler to ensure that things are parsed correctly when a 204 status code is returned on the get  `/rooms` call. This change should return some things to a state of expected behaviour